### PR TITLE
Remove zone param since not all AWS AZs have cn5.metal instances

### DIFF
--- a/ansible/deploy_kubevirt_worker.yml
+++ b/ansible/deploy_kubevirt_worker.yml
@@ -46,7 +46,6 @@
         machineset_ami_id: "{{ cluster_machinesets.resources[0].spec.template.spec.providerSpec.value.ami.id }}"
         machineset_subnet: "{{ cluster_machinesets.resources[0].spec.template.spec.providerSpec.value.subnet.filters[0]['values'][0] }}"
         machineset_tags: "{{ cluster_machinesets.resources[0].spec.template.spec.providerSpec.value.tags }}"
-        machineset_zone: "{{ cluster_machinesets.resources[0].spec.template.spec.providerSpec.value.placement.availabilityZone }}"
         infrastructure_name: "{{ cluster_info.resources[0].status.infrastructureName }}"
         infrastructure_region: "{{ cluster_info.resources[0].status.platformStatus.aws.region }}"
 
@@ -59,21 +58,21 @@
             labels:
               machine.openshift.io/cluster-api-cluster: "{{ infrastructure_name }}"
               edge-gitops-role: kubevirt-worker
-            name: "{{ infrastructure_name }}-{{ machineset_name }}-{{ machineset_zone }}"
+            name: "{{ infrastructure_name }}-{{ machineset_name }}"
             namespace: openshift-machine-api
           spec:
             replicas: {{ machineset_replicas | int }}
             selector:
               matchLabels:
                 machine.openshift.io/cluster-api-cluster: "{{ infrastructure_name }}"
-                machine.openshift.io/cluster-api-machineset: "{{ infrastructure_name }}-{{ machineset_name }}-{{ machineset_zone }}"
+                machine.openshift.io/cluster-api-machineset: "{{ infrastructure_name }}-{{ machineset_name }}"
             template:
               metadata:
                 labels:
                   machine.openshift.io/cluster-api-cluster: "{{ infrastructure_name }}"
                   machine.openshift.io/cluster-api-machine-role: "{{ machineset_machine_role }}"
                   machine.openshift.io/cluster-api-machine-type: "{{ machineset_machine_type }}"
-                  machine.openshift.io/cluster-api-machineset: "{{ infrastructure_name }}-{{ machineset_name }}-{{ machineset_zone }}"
+                  machine.openshift.io/cluster-api-machineset: "{{ infrastructure_name }}-{{ machineset_name }}"
           {% if machineset_os is defined %}
                   machine.openshift.io/os-id: {{ machineset_os }}
           {% endif %}
@@ -94,7 +93,6 @@
                     instanceType: "{{ machineset_instance_type }}"
                     kind: AWSMachineProviderConfig
                     placement:
-                      availabilityZone: "{{ machineset_zone }}"
                       region: "{{ infrastructure_region }}"
                     securityGroups:
                       - filters:


### PR DESCRIPTION
This caused a series of CI/CD failures in our system because the requested instance type was unavailable in a particular AZ. Since the AZ doesn't matter, we can let AWS pick one for us within the region.