### PR TITLE
Fixes for 4.15+ for new ODF and CNV behaviors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -42,3 +42,9 @@
 * Remove support for 4.10 (since it is out of support)
 * Update platform level override using new templated valuefile name feature in common
 * Skip multicloud gateway (noobaa) installation in ODF by default
+
+## Changes in main (July 25, 2024)
+
+* Introduce clean-golden-images job to imperative. This is a workaround for a bug in CNV 4.15/ODF 4.15 where if the default StorageClass is not the same as the default virtualization storage class, CNV cannot properly provision datavolumes.
+* Default storageclass for edge-gitops-vms to "ocs-storagecluster-ceph-rbd-virtualization", available since ODF 4.14.
+* Use api_version for Route queries when discovering credentials for AAP instance.

--- a/ansible/ansible_get_credentials.yml
+++ b/ansible/ansible_get_credentials.yml
@@ -10,6 +10,7 @@
   tasks:
     - name: Retrieve API hostname for AAP
       kubernetes.core.k8s_info:
+        api_version: route.openshift.io/v1
         kind: Route
         namespace: ansible-automation-platform
         name: controller

--- a/ansible/odf_clean_pvcs.yml
+++ b/ansible/odf_clean_pvcs.yml
@@ -1,0 +1,60 @@
+#!/usr/bin/env ansible-playbook
+---
+- name: Determine if we have PVC clean-up to do
+  become: false
+  connection: local
+  hosts: localhost
+  gather_facts: false
+  vars:
+    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+    pvc_cleanup: false
+    image_cleanup_namespace: "openshift-virtualization-os-images"
+  tasks:
+    - name: Find default storageclass
+      ansible.builtin.shell: |
+        oc get storageclass -o json | jq -r '.items[] | select(.metadata.annotations."storageclass.kubernetes.io/is-default-class")'
+      register: default_sc_output
+      changed_when: false
+
+    - name: Find virtualization default storageclass
+      ansible.builtin.shell: |
+        oc get storageclass -o json | jq -r '.items[] | select(.metadata.annotations."storageclass.kubevirt.io/is-default-virt-class")'
+      register: default_virt_sc_output
+      changed_when: false
+
+    - name: Trap errors
+      block:
+        - name: Parse results
+          ansible.builtin.set_fact:
+            default_sc: '{{ default_sc_output.stdout | from_json }}'
+            default_virt_sc: '{{ default_virt_sc_output.stdout | from_json }}'
+
+        - name: Commit to PVC cleanup
+          ansible.builtin.set_fact:
+            pvc_cleanup: true
+          when:
+            - default_virt_sc.metadata.name == "ocs-storagecluster-ceph-rbd-virtualization"
+            - default_sc.metadata.name != default_virt_sc.metadata.name
+
+        - name: Find PVCs
+          kubernetes.core.k8s_info:
+            kind: pvc
+            namespace: '{{ image_cleanup_namespace }}'
+          register: pvc_cleanup_list
+          when:
+            - pvc_cleanup
+
+        - name: Remove stray PVCs
+          kubernetes.core.k8s:
+            kind: pvc
+            namespace: '{{ image_cleanup_namespace }}'
+            name: '{{ item.metadata.name }}'
+            state: absent
+          loop: "{{ pvc_cleanup_list.resources }}"
+          when:
+            - pvc_cleanup
+            - item.spec.storageClassName != default_virt_sc.metadata.name
+      rescue:
+        - name: Note that we exited
+          ansible.builtin.debug:
+            msg: "Caught an error, exiting"

--- a/ansible/odf_clean_pvcs.yml
+++ b/ansible/odf_clean_pvcs.yml
@@ -82,7 +82,7 @@
             state: absent
           when:
             - item.status.phase in dv_remove_status
-            - (now(utc=true) - (item.metadata.creationTimestamp|to_datetime(ts_fmt))).seconds >= dv_remote_timeout
+            - (now(utc=true) - (item.metadata.creationTimestamp|to_datetime(ts_fmt))).seconds >= dv_remove_timeout
           loop: '{{ vm_ds.resources }}'
 
       rescue:

--- a/ansible/odf_clean_pvcs.yml
+++ b/ansible/odf_clean_pvcs.yml
@@ -79,7 +79,7 @@
             api_version: "{{ item.apiVersion }}"
             state: absent
           when:
-            - item.status.phase in dv_remove_stats
+            - item.status.phase in dv_remove_status
             - (now(utc=true) - (item.metadata.creationTimestamp|to_datetime(ts_fmt))).seconds >= dv_remote_timeout
           loop: '{{ vm_ds.resources }}'
 

--- a/ansible/odf_clean_pvcs.yml
+++ b/ansible/odf_clean_pvcs.yml
@@ -16,12 +16,14 @@
   tasks:
     - name: Find default storageclass
       ansible.builtin.shell: |
+        set -o pipefail
         oc get storageclass -o json | jq -r '.items[] | select(.metadata.annotations."storageclass.kubernetes.io/is-default-class")'
       register: default_sc_output
       changed_when: false
 
     - name: Find virtualization default storageclass
       ansible.builtin.shell: |
+        set -o pipefail
         oc get storageclass -o json | jq -r '.items[] | select(.metadata.annotations."storageclass.kubevirt.io/is-default-virt-class")'
       register: default_virt_sc_output
       changed_when: false

--- a/ansible/odf_clean_pvcs.yml
+++ b/ansible/odf_clean_pvcs.yml
@@ -11,7 +11,7 @@
     image_cleanup_namespace: "openshift-virtualization-os-images"
     dv_namespace: edge-gitops-vms
     dv_remove_timeout: 1800
-    dv_remove_states: [ "Pending" ]
+    dv_remove_status: ["Pending"]
     ts_fmt: '%Y-%m-%dT%H:%M:%S.%fZ'
   tasks:
     - name: Find default storageclass

--- a/ansible/odf_clean_pvcs.yml
+++ b/ansible/odf_clean_pvcs.yml
@@ -12,7 +12,7 @@
     dv_namespace: edge-gitops-vms
     dv_remove_timeout: 1800
     dv_remove_status: ["Pending"]
-    ts_fmt: '%Y-%m-%dT%H:%M:%S.%fZ'
+    ts_fmt: '%Y-%m-%dT%H:%M:%SZ'
   tasks:
     - name: Find default storageclass
       ansible.builtin.shell: |

--- a/ansible/odf_clean_pvcs.yml
+++ b/ansible/odf_clean_pvcs.yml
@@ -9,6 +9,10 @@
     kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
     pvc_cleanup: false
     image_cleanup_namespace: "openshift-virtualization-os-images"
+    dv_namespace: edge-gitops-vms
+    dv_remove_timeout: 1800
+    dv_remove_states: [ "Pending" ]
+    ts_fmt: '%Y-%m-%dT%H:%M:%S.%fZ'
   tasks:
     - name: Find default storageclass
       ansible.builtin.shell: |
@@ -22,7 +26,7 @@
       register: default_virt_sc_output
       changed_when: false
 
-    - name: Trap errors
+    - name: Compare default virtualization storageclass and default storageclass to determine whether to clean PVCs
       block:
         - name: Parse results
           ansible.builtin.set_fact:
@@ -35,16 +39,22 @@
           when:
             - default_virt_sc.metadata.name == "ocs-storagecluster-ceph-rbd-virtualization"
             - default_sc.metadata.name != default_virt_sc.metadata.name
+      rescue:
+        - name: Note that we exited
+          ansible.builtin.debug:
+            msg: "Caught an error before we could determine to clean up PVCs, exiting"
 
+    - name: Cleanup incorrect datasourceimport images (PVCs)
+      when:
+        - pvc_cleanup
+      block:
         - name: Find PVCs
           kubernetes.core.k8s_info:
             kind: pvc
             namespace: '{{ image_cleanup_namespace }}'
           register: pvc_cleanup_list
-          when:
-            - pvc_cleanup
 
-        - name: Remove stray PVCs
+        - name: Remove stray datasource PVCs
           kubernetes.core.k8s:
             kind: pvc
             namespace: '{{ image_cleanup_namespace }}'
@@ -52,9 +62,28 @@
             state: absent
           loop: "{{ pvc_cleanup_list.resources }}"
           when:
-            - pvc_cleanup
             - item.spec.storageClassName != default_virt_sc.metadata.name
+
+        - name: Check for stuck datavolumes
+          kubernetes.core.k8s_info:
+            namespace: '{{ dv_namespace }}'
+            kind: DataVolume
+            api_version: cdi.kubevirt.io/v1beta1
+          register: vm_ds
+
+        - name: Remove stuck datavolume if needed
+          kubernetes.core.k8s:
+            name: "{{ item.metadata.name }}"
+            namespace: "{{ item.metadata.namespace }}"
+            kind: "{{ item.kind }}"
+            api_version: "{{ item.apiVersion }}"
+            state: absent
+          when:
+            - item.status.phase in dv_remove_stats
+            - (now(utc=true) - (item.metadata.creationTimestamp|to_datetime(ts_fmt))).seconds >= dv_remote_timeout
+          loop: '{{ vm_ds.resources }}'
+
       rescue:
         - name: Note that we exited
           ansible.builtin.debug:
-            msg: "Caught an error, exiting"
+            msg: "Caught an error while cleaning up PVCs, exiting"

--- a/charts/hub/edge-gitops-vms/values.yaml
+++ b/charts/hub/edge-gitops-vms/values.yaml
@@ -11,7 +11,7 @@ cloudInitDefaultSecretName: secret/data/hub/cloud-init
 # Or "RWO" and "gp2"; other choices are possible too but
 # these are defaults for ODF which is included in the pattern
 defaultAccessMode: "ReadWriteMany"
-defaultStorageClassName: "ocs-storagecluster-ceph-rbd"
+defaultStorageClassName: "ocs-storagecluster-ceph-rbd-virtualization"
 defaultVolumeMode: "Block"
 
 vmNamespace: edge-gitops-vms

--- a/overrides/values-egv-4.15.yaml
+++ b/overrides/values-egv-4.15.yaml
@@ -1,2 +1,0 @@
----
-defaultStorageClass: ocs-storagecluster-ceph-rbd-virtualization

--- a/overrides/values-egv-4.15.yaml
+++ b/overrides/values-egv-4.15.yaml
@@ -1,0 +1,2 @@
+---
+defaultStorageClass: ocs-storagecluster-ceph-rbd-virtualization

--- a/tests/hub-edge-gitops-vms-industrial-edge-factory.expected.yaml
+++ b/tests/hub-edge-gitops-vms-industrial-edge-factory.expected.yaml
@@ -181,7 +181,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:
@@ -319,7 +319,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:

--- a/tests/hub-edge-gitops-vms-industrial-edge-hub.expected.yaml
+++ b/tests/hub-edge-gitops-vms-industrial-edge-hub.expected.yaml
@@ -181,7 +181,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:
@@ -319,7 +319,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:

--- a/tests/hub-edge-gitops-vms-medical-diagnosis-hub.expected.yaml
+++ b/tests/hub-edge-gitops-vms-medical-diagnosis-hub.expected.yaml
@@ -181,7 +181,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:
@@ -319,7 +319,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:

--- a/tests/hub-edge-gitops-vms-naked.expected.yaml
+++ b/tests/hub-edge-gitops-vms-naked.expected.yaml
@@ -181,7 +181,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:
@@ -319,7 +319,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:

--- a/tests/hub-edge-gitops-vms-normal.expected.yaml
+++ b/tests/hub-edge-gitops-vms-normal.expected.yaml
@@ -181,7 +181,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:
@@ -319,7 +319,7 @@ items:
           resources:
             requests:
               storage: 30Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+          storageClassName: ocs-storagecluster-ceph-rbd-virtualization
           volumeMode: Block
     running: true
     template:

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -39,7 +39,7 @@ clusterGroup:
       - name: configure-aap-controller
         playbook: ansible/imperative_configure_controller.yml
         image: quay.io/hybridcloudpatterns/ansible-edge-gitops-ee:latest
-        verbosity: -vvvvv
+        verbosity: -vvv
         timeout: "900"
     clusterRoleYaml:
       - apiGroups:

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -47,7 +47,7 @@ clusterGroup:
         resources:
           - machinesets
           - persistentvolumeclaims
-          - routes
+          - datavolumes
         verbs:
           - "*"
       - apiGroups:

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -95,6 +95,8 @@ clusterGroup:
       namespace: edge-gitops-vms
       project: hub
       path: charts/hub/edge-gitops-vms
+      extraValueFiles:
+        - '/overrides/values-egv-{{ $.Values.global.clusterVersion }}.yaml'
 
   # Only the hub cluster here - managed entities are edge nodes
   managedClusterGroups: []

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -32,16 +32,22 @@ clusterGroup:
       - name: deploy-kubevirt-worker
         playbook: ansible/deploy_kubevirt_worker.yml
         verbosity: -vvv
+      - name: clean-golden-images
+        playbook: ansible/odf_clean_pvcs.yml
+        image: quay.io/hybridcloudpatterns/utility-container:latest
+        verbosity: -vvv
       - name: configure-aap-controller
         playbook: ansible/imperative_configure_controller.yml
         image: quay.io/hybridcloudpatterns/ansible-edge-gitops-ee:latest
-        verbosity: -vvv
+        verbosity: -vvvvv
         timeout: "900"
     clusterRoleYaml:
       - apiGroups:
           - "*"
         resources:
           - machinesets
+          - persistentvolumeclaims
+          - routes
         verbs:
           - "*"
       - apiGroups:


### PR DESCRIPTION
* Introduce clean-golden-images job to imperative. This is a workaround for a bug in CNV 4.15/ODF 4.15 where if the default StorageClass is not the same as the default virtualization storage class, CNV cannot properly provision datavolumes.
* Default storageclass for edge-gitops-vms to "ocs-storagecluster-ceph-rbd-virtualization", available since ODF 4.14.
* Use api_version for Route queries when discovering credentials for AAP instance.