### PR TITLE
Update to allow main and v1.4 to run on OCP 4.12 and 4.13

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -50,3 +50,5 @@
 * Use api_version for Route queries when discovering credentials for AAP instance.
 * Update common.
 * Update deploy_kubevirt_worker.yml Ansible playbook to copy securityGroups and blockDevices config from first machineSet. Tag naming schemes changed from OCP 4.15 to 4.16; this method ensures forward and backward compatibility.
+* Remove ODF overrides from OCP 4.12/3 that force storageClass to gp2; all released versions should use gp3-csi now.
+* Include overrides for OCP 4.12 and OCP 4.13 to use the older `ocs-storagecluster-ceph-rbd` storageClass.

--- a/common/.ansible-lint
+++ b/common/.ansible-lint
@@ -16,5 +16,6 @@ exclude_paths:
   - ./ansible/playbooks/iib-ci/iib-ci.yaml
   - ./ansible/playbooks/k8s_secrets/k8s_secrets.yml
   - ./ansible/playbooks/process_secrets/process_secrets.yml
+  - ./ansible/playbooks/write-token-kubeconfig/write-token-kubeconfig.yml
   - ./ansible/playbooks/process_secrets/display_secrets_info.yml
   - ./ansible/roles/vault_utils/tests/test.yml

--- a/common/Makefile
+++ b/common/Makefile
@@ -119,6 +119,9 @@ load-iib: ## CI target to install Index Image Bundles
 		exit 1; \
 	fi
 
+.PHONY: token-kubeconfig
+token-kubeconfig: ## Create a local ~/.kube/config with password (not usually needed)
+	common/scripts/write-token-kubeconfig.sh
 
 ##@ Validation Tasks
 

--- a/common/ansible/playbooks/write-token-kubeconfig/write-token-kubeconfig.yml
+++ b/common/ansible/playbooks/write-token-kubeconfig/write-token-kubeconfig.yml
@@ -1,0 +1,93 @@
+---
+- name: Test k8s authentication methods
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  vars:
+    kubeconfig_file: '~/.kube/config'
+    k8s_host: '{{ lookup("env", "K8S_AUTH_HOST") }}'
+    k8s_validate_certs: '{{ lookup("env", "K8S_AUTH_VERIFY_SSL") | default(false) | bool }}'
+    k8s_username: '{{ lookup("env", "K8S_AUTH_USERNAME") | default("kubeconfig") }}'
+    k8s_password: '{{ lookup("env", "K8S_AUTH_PASSWORD") | default(omit) }}'
+    k8s_api_key: '{{ lookup("env", "K8S_AUTH_TOKEN") | default(omit) }}'
+    k8s_ca_cert_file: '{{ lookup("env", "K8S_AUTH_SSL_CA_CERT") | default(omit) }}'
+  tasks:
+    - name: Check for pre-existing kubeconfig
+      ansible.builtin.stat:
+        path: '{{ kubeconfig_file }}'
+      register: kubeconfig_stat
+
+    - name: Exit if kubeconfig found
+      ansible.builtin.fail:
+        msg: '{{ kubeconfig_file }} already exists! Exiting'
+      when: kubeconfig_stat.stat.exists
+
+    - name: Get namespaces to test parameters
+      kubernetes.core.k8s_info:
+        host: '{{ k8s_host }}'
+        validate_certs: '{{ k8s_validate_certs }}'
+        username: '{{ k8s_username }}'
+        api_key: '{{ k8s_api_key }}'
+        ca_cert: '{{ k8s_ca_cert_file | default(omit) }}'
+        kind: namespace
+      when: k8s_api_key
+
+    - name: Login explicitly
+      when: not k8s_api_key
+      block:
+        - name: Login explicitly to get token
+          kubernetes.core.k8s_auth:
+            host: '{{ k8s_host }}'
+            validate_certs: '{{ k8s_validate_certs }}'
+            username: '{{ k8s_username }}'
+            password: '{{ k8s_password }}'
+            ca_cert: '{{ k8s_ca_cert_file | default(omit) }}'
+          register: auth
+
+        - name: Set api_key
+          ansible.builtin.set_fact:
+            k8s_api_key: '{{ auth.openshift_auth.api_key }}'
+
+    - name: Update username if needed
+      ansible.builtin.set_fact:
+        config_k8s_username: 'kube:admin'
+      when: k8s_username == 'kubeadmin'
+
+    - name: Determine clustername
+      ansible.builtin.set_fact:
+        config_k8s_clustername: "{{ k8s_host | regex_replace('https://', '') | regex_replace('\\.', '-') }}"
+
+    - name: Write config file
+      ansible.builtin.copy:
+        content: |-
+          apiVersion: v1
+          clusters:
+            - cluster:
+          {% if k8s_validate_certs is false %}
+                insecure-skip-tls-verify: true
+          {% endif %}
+          {% if k8s_ca_cert_file -%}
+                certificate-authority-data: {{ lookup("file", k8s_ca_cert_file) | b64encode }}
+          {% endif %}
+                server: {{ k8s_host }}
+              name: {{ config_k8s_clustername }}
+          contexts:
+            - context:
+                cluster: {{ config_k8s_clustername }}
+                namespace: default
+                user: {{ config_k8s_username | default(k8s_username) }}/{{ config_k8s_clustername }}
+              name: default/{{ config_k8s_clustername }}/{{ config_k8s_username | default(k8s_username) }}
+          current-context: default/{{ config_k8s_clustername }}/{{ config_k8s_username | default(k8s_username) }}
+          kind: Config
+          preferences: {}
+          users:
+            - name: {{ config_k8s_username | default(k8s_username) }}/{{ config_k8s_clustername }}
+              user:
+                token: {{ k8s_api_key }}
+        dest: '{{ kubeconfig_file }}'
+        mode: '0640'
+
+    - name: Notify user
+      ansible.builtin.debug:
+        msg: "Wrote {{ kubeconfig_file }}"

--- a/common/scripts/pattern-util.sh
+++ b/common/scripts/pattern-util.sh
@@ -67,6 +67,12 @@ podman run -it --rm --pull=newer \
 	-e EXTRA_HELM_OPTS \
 	-e EXTRA_PLAYBOOK_OPTS \
 	-e KUBECONFIG \
+	-e K8S_AUTH_HOST \
+	-e K8S_AUTH_VERIFY_SSL \
+	-e K8S_AUTH_SSL_CA_CERT \
+	-e K8S_AUTH_USERNAME \
+	-e K8S_AUTH_PASSWORD \
+	-e K8S_AUTH_TOKEN \
 	-v "${PKI_HOST_MOUNT}":/etc/pki:ro \
 	-v "${HOME}":"${HOME}" \
 	-v "${HOME}":/pattern-home \

--- a/common/scripts/write-token-kubeconfig.sh
+++ b/common/scripts/write-token-kubeconfig.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eu
+
+OUTPUTFILE=${1:-"~/.kube/config"}
+
+get_abs_filename() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+SCRIPT=$(get_abs_filename "$0")
+SCRIPTPATH=$(dirname "${SCRIPT}")
+COMMONPATH=$(dirname "${SCRIPTPATH}")
+PATTERNPATH=$(dirname "${COMMONPATH}")
+ANSIBLEPATH="$(dirname ${SCRIPTPATH})/ansible"
+PLAYBOOKPATH="${ANSIBLEPATH}/playbooks"
+export ANSIBLE_CONFIG="${ANSIBLEPATH}/ansible.cfg"
+
+ansible-playbook -e pattern_dir="${PATTERNPATH}" -e kubeconfig_file="${OUTPUTFILE}" "${PLAYBOOKPATH}/write-token-kubeconfig/write-token-kubeconfig.yml"

--- a/overrides/values-egv-4.12.yaml
+++ b/overrides/values-egv-4.12.yaml
@@ -1,0 +1,1 @@
+values-egv-4.13.yaml

--- a/overrides/values-egv-4.13.yaml
+++ b/overrides/values-egv-4.13.yaml
@@ -1,0 +1,2 @@
+---
+defaultStorageClassName: "ocs-storagecluster-ceph-rbd"

--- a/overrides/values-odf-AWS-4.12.yaml
+++ b/overrides/values-odf-AWS-4.12.yaml
@@ -1,1 +1,0 @@
-values-odf-AWS-4.13.yaml

--- a/overrides/values-odf-AWS-4.13.yaml
+++ b/overrides/values-odf-AWS-4.13.yaml
@@ -1,4 +1,0 @@
----
-global:
-  datacenter:
-    storageClassName: gp2

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -93,8 +93,6 @@ clusterGroup:
       namespace: openshift-storage
       project: hub
       path: charts/hub/openshift-data-foundations
-      extraValueFiles:
-        - '/overrides/values-odf-{{ $.Values.global.clusterPlatform }}-{{ $.Values.global.clusterVersion }}.yaml'
 
     edge-gitops-vms:
       name: edge-gitops-vms


### PR DESCRIPTION
* Remove ODF overrides from OCP 4.12/3 that force storageClass to gp2; all released versions should use gp3-csi now.
* Include overrides for OCP 4.12 and OCP 4.13 to use the older `ocs-storagecluster-ceph-rbd` storageClass.