### PR TITLE
Specify stable channel for OCP-V

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -20,6 +20,7 @@ clusterGroup:
     openshift-virtualization:
       name: kubevirt-hyperconverged
       namespace: openshift-cnv
+      channel: stable
 
     openshift-data-foundation:
       name: odf-operator


### PR DESCRIPTION
Otherwise, we will get the dev preview version of OCP Virtualization, because it provides a dev preview channel that will be preferred if no channel is specified.